### PR TITLE
Use forked workers to share model

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import multiprocessing
 from dataclasses import dataclass
 from typing import List
 
@@ -8,11 +9,7 @@ from datasets import load_dataset, Dataset
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
-def init_distributed():
-    if torch.distributed.is_available() and torch.distributed.is_initialized():
-        return
-    if int(os.environ.get("WORLD_SIZE", 1)) > 1:
-        torch.distributed.init_process_group("nccl")
+STREAMER: "Streamer" | None = None
 
 
 @dataclass
@@ -26,6 +23,7 @@ class Args:
     sampling_rounds: int
     push_every: int
     max_seq_len: int
+    num_workers: int
     hf_token: str | None = None
 
 
@@ -45,14 +43,15 @@ def parse_args() -> Args:
     )
     parser.add_argument("--push_every", type=int, default=1000)
     parser.add_argument("--max_seq_len", type=int, default=2048)
+    parser.add_argument("--num_workers", type=int, default=1)
     parser.add_argument("--hf_token", default=None)
     args = parser.parse_args()
     return Args(**vars(args))
 
 
 class Streamer:
-    def __init__(self, model_name: str, device: torch.device):
-        self.device = device
+    def __init__(self, model_name: str):
+        self.device = torch.device("cpu")
         self.model = AutoModelForCausalLM.from_pretrained(
             model_name, device_map={"": "cpu"}, torch_dtype=torch.float16
         )
@@ -60,19 +59,25 @@ class Streamer:
         self.embed = self.model.model.embed_tokens
         self.lm_head = self.model.lm_head
 
-    def forward(self, input_ids: torch.Tensor, micro_batch_size: int) -> torch.Tensor:
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        micro_batch_size: int,
+        device: torch.device | None = None,
+    ) -> torch.Tensor:
+        device = device or self.device
         batches = [
-            input_ids[i : i + micro_batch_size].to(self.device)
+            input_ids[i : i + micro_batch_size].to(device)
             for i in range(0, input_ids.size(0), micro_batch_size)
         ]
 
-        self.embed.to(self.device)
+        self.embed.to(device)
         hidden = [self.embed(mb) for mb in batches]
         self.embed.to("cpu")
         torch.cuda.empty_cache()
 
         for layer in self.layers:
-            layer.to(self.device)
+            layer.to(device)
             next_hidden = []
             for h in hidden:
                 out = layer(h)
@@ -82,7 +87,7 @@ class Streamer:
             layer.to("cpu")
             torch.cuda.empty_cache()
 
-        self.lm_head.to(self.device)
+        self.lm_head.to(device)
         logits = [self.lm_head(h) for h in hidden]
         self.lm_head.to("cpu")
         torch.cuda.empty_cache()
@@ -120,11 +125,23 @@ def collate_fn(examples, tokenizer, max_seq_len: int):
     )
 
 
-def main():
-    args = parse_args()
-    init_distributed()
-    local_rank = int(os.environ.get("LOCAL_RANK", 0))
-    device = torch.device(f"cuda:{local_rank}") if torch.cuda.is_available() else torch.device("cpu")
+def streaming_dataloader(ds, tokenizer, batch_size: int, max_seq_len: int):
+    batch = []
+    for example in ds:
+        batch.append(example)
+        if len(batch) == batch_size:
+            yield collate_fn(batch, tokenizer, max_seq_len)
+            batch.clear()
+    if batch:
+        yield collate_fn(batch, tokenizer, max_seq_len)
+
+
+def worker_main(rank: int, args: Args):
+    global STREAMER
+    device = (
+        torch.device(f"cuda:{rank}") if torch.cuda.is_available() else torch.device("cpu")
+    )
+    STREAMER.device = device
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
     dataset = load_dataset(
         args.dataset_name,
@@ -132,31 +149,15 @@ def main():
         token=args.hf_token,
         streaming=True,
     )
+    dataset = dataset.shard(num_shards=args.num_workers, index=rank)
 
-    if torch.distributed.is_initialized():
-        dataset = dataset.shard(
-            num_shards=torch.distributed.get_world_size(),
-            index=local_rank,
-        )
-
-    def streaming_dataloader(ds):
-        batch = []
-        for example in ds:
-            batch.append(example)
-            if len(batch) == args.batch_size:
-                yield collate_fn(batch, tokenizer, args.max_seq_len)
-                batch.clear()
-        if batch:
-            yield collate_fn(batch, tokenizer, args.max_seq_len)
-
-    dataloader = streaming_dataloader(dataset)
-    streamer = Streamer(args.model_name, device)
+    dataloader = streaming_dataloader(dataset, tokenizer, args.batch_size, args.max_seq_len)
 
     all_records: List[dict] = []
     total = 0
     for batch in dataloader:
         input_ids = batch["input_ids"]
-        logits = streamer.forward(input_ids, args.micro_batch_size)
+        logits = STREAMER.forward(input_ids, args.micro_batch_size, device)
         ids, probs = sample_distribution(logits, args.sampling_rounds)
         for i in range(len(input_ids)):
             record = {
@@ -174,6 +175,25 @@ def main():
     if all_records:
         ds = Dataset.from_list(all_records)
         ds.push_to_hub(args.output_repo, token=args.hf_token, append=True)
+
+
+def main():
+    args = parse_args()
+
+    mp = multiprocessing.get_context("fork")
+    global STREAMER
+    STREAMER = Streamer(args.model_name)
+
+    if args.num_workers > 1:
+        processes = []
+        for rank in range(args.num_workers):
+            p = mp.Process(target=worker_main, args=(rank, args))
+            p.start()
+            processes.append(p)
+        for p in processes:
+            p.join()
+    else:
+        worker_main(0, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid reloading the model for each process
- launch multiple workers via `multiprocessing` with a shared `Streamer`
- allow device selection per worker and add `--num_workers` argument

## Testing
- `python -m py_compile generator.py`

------
https://chatgpt.com/codex/tasks/task_e_683dd21bc6288323a7d6503340fc3c42