### PR TITLE
Add future annotations import to generator

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 import multiprocessing


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` to `generator.py`

## Testing
- `python generator.py --help` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683ddc61d55c8323b477f275ffe8b9d8