### PR TITLE
Fix collate_fn error in generator

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -130,8 +130,9 @@ def sample_distribution(logits: torch.Tensor, rounds: int):
 
 
 def collate_fn(examples, tokenizer, max_seq_len: int):
+    texts = [e["text"] for e in examples]
     return tokenizer(
-        examples["text"],
+        texts,
         return_tensors="pt",
         padding=True,
         truncation=True,


### PR DESCRIPTION
## Summary
- handle batches correctly in `collate_fn`

## Testing
- `python generator.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683f74c16d3c8323a3ac80221d384526