### PR TITLE
Fix sampling degeneracy with zero probabilities

### DIFF
--- a/SAMPLING.md
+++ b/SAMPLING.md
@@ -13,7 +13,7 @@ The goal is to approximate the full softmax distribution of the teacher model wh
    - Given the raw logits for a sequence, compute the teacher distribution `p` via `softmax(logits)`.
    - Compute a proposal distribution `q` by applying temperature to the logits and then softmax: `q = softmax(logits / temperature)`.
    - Sampling temperatures in the range **0.8**–**1.2** generally give the lowest variance.
-   - Replace any `NaN` or infinite values in `q` with zero and clamp negative entries to `0`.  If the resulting distribution becomes degenerate (all zeros or non‑finite) fall back to a uniform distribution before normalising.
+   - Replace any `NaN` or infinite values in `q` with zero and clamp negative entries to `0`.  If the resulting distribution becomes degenerate (all zeros or non‑finite) fall back to a uniform distribution before normalising.  Otherwise add a small `1e-6` to avoid zero probabilities before normalising.
 
 2. **Draw Samples**
    - For every position in the sequence, draw `rounds` samples from `q` with replacement using `torch.multinomial`.

--- a/generator.py
+++ b/generator.py
@@ -183,6 +183,8 @@ def sample_distribution(
             if not torch.isfinite(q_row).all() or q_row.sum() == 0:
                 q_row.fill_(1.0 / q_row.numel())
             else:
+                # avoid zero probabilities that can cause degenerate sampling
+                q_row = q_row + 1e-6
                 q_row /= q_row.sum()
 
             # multinomial expects non-negative weights


### PR DESCRIPTION
## Summary
- avoid zero probability values when sanitizing the proposal distribution
- document new epsilon in the sampling procedure

## Testing
- `python -m py_compile generator.py`


------
https://chatgpt.com/codex/tasks/task_e_683fa689e28083239707dc1cdd820fbf