### PR TITLE
Use torch.no_grad for inference

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -83,6 +83,7 @@ class Streamer:
         else:
             self.streams = [torch.cuda.current_stream()]
 
+    @torch.no_grad()
     def forward(
         self,
         input_ids: torch.Tensor,


### PR DESCRIPTION
## Summary
- wrap `Streamer.forward` in `torch.no_grad` so inference does not store gradients

## Testing
- `python -m py_compile generator.py`


------
https://chatgpt.com/codex/tasks/task_e_683facac11cc83239b43d59d885fe628